### PR TITLE
Add implementation plan and update guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@ This repository is a PNPM based monorepo. It contains:
 
 - `packages/frontend` – React + Vite project managed with **AWS Amplify**.
 - `packages/backend` – AWS CDK infrastructure with Go Lambda functions.
+- `app_design` – Planning docs and prototype reference code.
 
 ## Getting Started
 1. Install dependencies from the repo root: `pnpm install`.
@@ -15,6 +16,12 @@ This repository is a PNPM based monorepo. It contains:
    - Backend linting is not yet configured.
 4. Run backend tests with `pnpm run backend:test` when backend code changes.
 5. Update documentation and design docs in `packages/backend/backend_design_docs` when backend APIs change.
+
+## Design Reference
+The high level product requirements live in `app_design/Design_specs.md`. A working
+prototype is provided under `app_design/proto-mrn` and serves as the starting
+point for the Amplify application. When planning new features or infrastructure,
+review these files first.
 
 ## Notes
 - This project uses Node 22+ and pnpm 10.11.1.

--- a/app_design/Implementation_Plan.md
+++ b/app_design/Implementation_Plan.md
@@ -1,0 +1,32 @@
+# Initial Implementation Plan
+
+This document outlines how to bootstrap the Miliare application using AWS Amplify and later transition to a production stack managed by the AWS CDK.
+
+## Phase 1: Amplify Prototype
+1. **Bootstrap from `proto-mrn`:**
+   - Copy the contents of `app_design/proto-mrn` into `packages/frontend`.
+   - Configure Amplify authentication (Cognito) and connect the prototype React code.
+2. **Rapid data layer:**
+   - Use Amplify's DataStore and auto-generated GraphQL API for early development.
+   - Model schemas based on `app_design/Design_specs.md` and iterate quickly.
+3. **Environment management:**
+   - Use Amplify environments for separate dev and QA stacks.
+4. **CI/CD:**
+   - Leverage Amplify Console for automatic frontend deployments on push.
+
+## Phase 2: Production Backend with CDK
+1. **CDK Infrastructure:**
+   - Mirror Amplify resources (Cognito, AppSync, DynamoDB) using the CDK in `packages/backend`.
+   - Implement custom Go Lambda resolvers where Amplify auto-generated code is insufficient.
+2. **Data Migration:**
+   - Export data from the Amplify-managed backend and import it into the CDK-managed resources.
+   - Coordinate cut-over by updating environment variables and Amplify configuration to point to the new endpoints.
+3. **Testing & Validation:**
+   - Ensure parity between Amplify and CDK deployments before switching production traffic.
+   - Maintain a rollback plan to the Amplify environment if issues arise.
+
+## Phase 3: Decommission Amplify Backend
+1. Once the CDK stack is stable, remove backend resources from Amplify, leaving it to manage only the frontend hosting if desired.
+2. Update project documentation to reflect the new architecture.
+
+This phased approach allows quick iteration with Amplify while building a robust CDK-based backend for long-term maintainability.


### PR DESCRIPTION
## Summary
- update `AGENTS.md` with pointers to design docs
- add initial implementation plan describing Amplify prototype and CDK migration

## Testing
- `pnpm run frontend:lint`

------
https://chatgpt.com/codex/tasks/task_e_6841d758c634832dabe14a8f2e102f8b