### PR TITLE
Fix tests and update docs for Amplify Gen 2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ This repository is a PNPM based monorepo. It contains:
 1. Install dependencies from the repo root: `pnpm install`.
 2. Work in the appropriate package:
    - Frontend: use `pnpm run frontend:dev` for local development.
-   - Backend: use `pnpm run backend:deploy` to deploy the CDK stack.
+   - Backend: run `npx ampx pipeline-deploy --branch <branch> --app-id <appId>` to deploy the Amplify Gen&nbsp;2 stack.
 3. Lint all code before committing:
    - Frontend: `pnpm run frontend:lint`.
    - Backend linting is not yet configured.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## AWS Amplify React+Vite Starter Template
 
-This repository provides a starter template for creating applications using React+Vite and AWS Amplify, emphasizing easy setup for authentication, API, and database capabilities.
+This repository provides a starter template for creating applications using React+Vite and AWS Amplify **Gen&nbsp;2**, emphasizing easy setup for authentication, API, and database capabilities.
 
 ## Overview
 
@@ -14,7 +14,14 @@ This template equips you with a foundational React application integrated with A
 
 ## Deploying to AWS
 
-For detailed instructions on deploying your application, refer to the [deployment section](https://docs.amplify.aws/react/start/quickstart/#deploy-a-fullstack-app-to-aws) of our documentation.
+To deploy using Amplify Gen&nbsp;2, run the backend pipeline deploy command from the repository root:
+
+```bash
+npx ampx pipeline-deploy --branch <branch> --app-id <appId>
+```
+
+This will provision the backend defined in `packages/frontend/amplify` and build the frontend located in `packages/frontend`.
+Refer to the [deployment section](https://docs.amplify.aws/gen2/deploy/pipelines/) for more details.
 
 ## Security
 

--- a/packages/frontend/README.md
+++ b/packages/frontend/README.md
@@ -8,8 +8,12 @@ This codebase provides a clean starting point with established patterns and conf
 
 ## Usage
 1. Clone or copy this directory to use as a starting point
-2. Install dependencies using `npm install` or `pnpm install`
-3. Follow the development instructions in the parent repository
+2. Install dependencies using `pnpm install` from the repository root
+3. Deploy the backend with Amplify Gen&nbsp;2:
+   ```bash
+   npx ampx pipeline-deploy --branch <branch> --app-id <appId>
+   ```
+4. Follow the development instructions in the parent repository
 
 ## Notes
 - This reference implementation has been stripped of all version control metadata to serve as clean starter code

--- a/packages/frontend/src/__tests__/RegisterPage.test.tsx
+++ b/packages/frontend/src/__tests__/RegisterPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import RegisterPage from '../pages/RegisterPage';
 import { AuthProvider } from '../contexts/AuthContext';


### PR DESCRIPTION
## Summary
- fix failing lint test for RegisterPage
- document Amplify Gen 2 pipeline usage in `AGENTS.md`, root `README`, and the frontend `README`

## Testing
- `pnpm run frontend:lint`
- `pnpm run frontend:test`
- `pnpm run frontend:build`


------
https://chatgpt.com/codex/tasks/task_e_684206a6da78832dab618ee0af01940c