### PR TITLE
Fix unused error vars in frontend

### DIFF
--- a/packages/frontend/src/contexts/AuthContext.tsx
+++ b/packages/frontend/src/contexts/AuthContext.tsx
@@ -48,7 +48,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
         setUser(userData);
       }
     } catch (error) {
-      // User is not authenticated
+      console.error('Error checking auth status:', error);
       setUser(null);
     } finally {
       setIsLoading(false);

--- a/packages/frontend/src/pages/LoginPage.tsx
+++ b/packages/frontend/src/pages/LoginPage.tsx
@@ -37,6 +37,7 @@ const LoginPage = () => {
       toast.success('Login successful', 'Welcome back!');
       navigate('/dashboard');
     } catch (error) {
+      console.error('Login error:', error);
       toast.error('Login failed', 'Please check your credentials and try again.');
     } finally {
       setIsLoading(false);

--- a/packages/frontend/src/pages/RegisterPage.tsx
+++ b/packages/frontend/src/pages/RegisterPage.tsx
@@ -118,6 +118,7 @@ const RegisterPage = () => {
       toast.success('Registration successful', 'Your account has been created!');
       navigate('/dashboard');
     } catch (error) {
+      console.error('Registration error:', error);
       toast.error('Registration failed', 'Please try again later.');
     } finally {
       setIsSubmitting(false);


### PR DESCRIPTION
## Summary
- use the caught error values in AuthContext, LoginPage and RegisterPage
- update linted catch blocks

## Testing
- `pnpm run frontend:lint`
- `pnpm run frontend:test`


------
https://chatgpt.com/codex/tasks/task_e_68423e0ecef4832d9952dc0e9386ba7e