### PR TITLE
Enable admin role to access all pages

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -18,7 +18,11 @@ const ProtectedRoute = ({ children, requiredGroup }: { children: React.ReactNode
     return <Navigate to="/login" replace />;
   }
 
-  if (requiredGroup && !user?.groups?.includes(requiredGroup)) {
+  if (
+    requiredGroup &&
+    !user?.groups?.includes(requiredGroup) &&
+    !user?.groups?.includes('admin')
+  ) {
     return <Navigate to="/dashboard" replace />;
   }
 

--- a/packages/frontend/src/__tests__/TeamAccess.test.tsx
+++ b/packages/frontend/src/__tests__/TeamAccess.test.tsx
@@ -40,6 +40,27 @@ describe('Team access', () => {
     expect(screen.getByRole('link', { name: /team/i })).toBeInTheDocument();
   });
 
+  it('shows Team link for users in admin group', () => {
+    vi.spyOn(AuthContext, 'useAuth').mockReturnValue({
+      ...baseAuth,
+      user: {
+        id: '1',
+        name: 'Admin',
+        email: 'admin@example.com',
+        company: 'WFG',
+        groups: ['admin'],
+      },
+    } as UseAuthReturn);
+
+    render(
+      <MemoryRouter>
+        <DashboardLayout />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole('link', { name: /team/i })).toBeInTheDocument();
+  });
+
   it('hides Team link for users without teamLead group', () => {
     vi.spyOn(AuthContext, 'useAuth').mockReturnValue({
       ...baseAuth,
@@ -61,7 +82,7 @@ describe('Team access', () => {
     expect(screen.queryByRole('link', { name: /team/i })).not.toBeInTheDocument();
   });
 
-  it('restricts /dashboard/team route to team leads', () => {
+  it('restricts /dashboard/team route when user lacks required groups', () => {
     vi.spyOn(AuthContext, 'useAuth').mockReturnValue({
       ...baseAuth,
       user: {
@@ -92,6 +113,27 @@ describe('Team access', () => {
         email: 'lead@example.com',
         company: 'WFG',
         groups: ['teamLead'],
+      },
+    } as UseAuthReturn);
+
+    render(
+      <MemoryRouter initialEntries={["/dashboard/team"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText(/your team dashboard/i)).toBeInTheDocument();
+  });
+
+  it('allows admins to view the team dashboard', () => {
+    vi.spyOn(AuthContext, 'useAuth').mockReturnValue({
+      ...baseAuth,
+      user: {
+        id: '1',
+        name: 'Admin',
+        email: 'admin@example.com',
+        company: 'WFG',
+        groups: ['admin'],
       },
     } as UseAuthReturn);
 

--- a/packages/frontend/src/layouts/DashboardLayout.tsx
+++ b/packages/frontend/src/layouts/DashboardLayout.tsx
@@ -47,7 +47,7 @@ const DashboardLayout = () => {
     { to: '/dashboard/refer', icon: <Share2 className="h-5 w-5" />, label: 'Refer' },
   ];
 
-  if (user?.groups?.includes('teamLead')) {
+  if (user?.groups?.includes('teamLead') || user?.groups?.includes('admin')) {
     navLinks.push({ to: '/dashboard/team', icon: <Users className="h-5 w-5" />, label: 'Team' });
   }
   


### PR DESCRIPTION
## Summary
- allow admin group to bypass ProtectedRoute restrictions
- show Team page link when user is admin
- test admin access to Team page and navigation

## Testing
- `pnpm run frontend:lint`
- `pnpm run frontend:test`


------
https://chatgpt.com/codex/tasks/task_e_6842d59334b0832d8587c280c22b9bcb