### PR TITLE
Add admin-only dashboard page

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import LearnPage from './pages/dashboard/LearnPage';
 import ReferPage from './pages/dashboard/ReferPage';
 import PartnerDetailPage from './pages/dashboard/PartnerDetailPage';
 import TeamPage from './pages/dashboard/TeamPage';
+import AdminPage from './pages/dashboard/AdminPage';
 import { Toaster } from './components/ui/Toaster';
 
 // Protected route component
@@ -49,6 +50,11 @@ function App() {
           <Route path="team" element={
             <ProtectedRoute requiredGroup="teamLead">
               <TeamPage />
+            </ProtectedRoute>
+          } />
+          <Route path="admin" element={
+            <ProtectedRoute requiredGroup="admin">
+              <AdminPage />
             </ProtectedRoute>
           } />
           <Route path="partners/:partnerId" element={<PartnerDetailPage />} />

--- a/packages/frontend/src/__tests__/AdminAccess.test.tsx
+++ b/packages/frontend/src/__tests__/AdminAccess.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import DashboardLayout from '../layouts/DashboardLayout';
+import App from '../App';
+import * as AuthContext from '../contexts/AuthContext';
+
+type UseAuthReturn = ReturnType<typeof AuthContext.useAuth>;
+
+const baseAuth = {
+  isAuthenticated: true,
+  isLoading: false,
+  login: vi.fn(),
+  logout: vi.fn(),
+  register: vi.fn(),
+};
+
+describe('Admin access', () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('shows Admin link for users in admin group', () => {
+    vi.spyOn(AuthContext, 'useAuth').mockReturnValue({
+      ...baseAuth,
+      user: {
+        id: '1',
+        name: 'Admin',
+        email: 'admin@example.com',
+        company: 'WFG',
+        groups: ['admin'],
+      },
+    } as UseAuthReturn);
+
+    render(
+      <MemoryRouter>
+        <DashboardLayout />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole('link', { name: /admin/i })).toBeInTheDocument();
+  });
+
+  it('hides Admin link for users without admin group', () => {
+    vi.spyOn(AuthContext, 'useAuth').mockReturnValue({
+      ...baseAuth,
+      user: {
+        id: '1',
+        name: 'User',
+        email: 'user@example.com',
+        company: 'WFG',
+        groups: [],
+      },
+    } as UseAuthReturn);
+
+    render(
+      <MemoryRouter>
+        <DashboardLayout />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByRole('link', { name: /admin/i })).not.toBeInTheDocument();
+  });
+
+  it('restricts /dashboard/admin route when user lacks admin group', () => {
+    vi.spyOn(AuthContext, 'useAuth').mockReturnValue({
+      ...baseAuth,
+      user: {
+        id: '1',
+        name: 'User',
+        email: 'user@example.com',
+        company: 'WFG',
+        groups: [],
+      },
+    } as UseAuthReturn);
+
+    render(
+      <MemoryRouter initialEntries={["/dashboard/admin"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByText(/admin dashboard/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/your business dashboard/i)).toBeInTheDocument();
+  });
+
+  it('allows admins to view the admin dashboard', () => {
+    vi.spyOn(AuthContext, 'useAuth').mockReturnValue({
+      ...baseAuth,
+      user: {
+        id: '1',
+        name: 'Admin',
+        email: 'admin@example.com',
+        company: 'WFG',
+        groups: ['admin'],
+      },
+    } as UseAuthReturn);
+
+    render(
+      <MemoryRouter initialEntries={["/dashboard/admin"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText(/admin dashboard/i)).toBeInTheDocument();
+  });
+});

--- a/packages/frontend/src/layouts/DashboardLayout.tsx
+++ b/packages/frontend/src/layouts/DashboardLayout.tsx
@@ -50,6 +50,10 @@ const DashboardLayout = () => {
   if (user?.groups?.includes('teamLead') || user?.groups?.includes('admin')) {
     navLinks.push({ to: '/dashboard/team', icon: <Users className="h-5 w-5" />, label: 'Team' });
   }
+
+  if (user?.groups?.includes('admin')) {
+    navLinks.push({ to: '/dashboard/admin', icon: <Settings className="h-5 w-5" />, label: 'Admin' });
+  }
   
   return (
     <div className="min-h-screen bg-gray-50 flex flex-col">

--- a/packages/frontend/src/pages/dashboard/AdminPage.tsx
+++ b/packages/frontend/src/pages/dashboard/AdminPage.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+const AdminPage = () => {
+  return (
+    <div className="space-y-8">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">Admin Dashboard</h1>
+        <p className="mt-1 text-sm text-gray-500">
+          Administrative tools and settings.
+        </p>
+      </div>
+      <div className="bg-white p-6 rounded-lg shadow-sm border border-gray-100">
+        <p className="text-gray-700">Only users in the admin group can see this page.</p>
+      </div>
+    </div>
+  );
+};
+
+export default AdminPage;


### PR DESCRIPTION
## Summary
- create `AdminPage` component to display admin content
- expose the new page via `/dashboard/admin` route
- add conditional Admin link in `DashboardLayout`
- test visibility and routing logic for admins

## Testing
- `pnpm run frontend:lint`
- `pnpm run frontend:test`


------
https://chatgpt.com/codex/tasks/task_e_6842df828e90832da1f9d2c6a23306db