### PR TITLE
Add email verification flow

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import ReferPage from './pages/dashboard/ReferPage';
 import PartnerDetailPage from './pages/dashboard/PartnerDetailPage';
 import TeamPage from './pages/dashboard/TeamPage';
 import AdminPage from './pages/dashboard/AdminPage';
+import VerifyEmailPage from './pages/VerifyEmailPage';
 import { Toaster } from './components/ui/Toaster';
 
 // Protected route component
@@ -37,6 +38,7 @@ function App() {
         {/* Public routes */}
         <Route path="/login" element={<LoginPage />} />
         <Route path="/register" element={<RegisterPage />} />
+        <Route path="/verify" element={<VerifyEmailPage />} />
         
         {/* Protected routes */}
         <Route path="/dashboard" element={

--- a/packages/frontend/src/contexts/AuthContext.tsx
+++ b/packages/frontend/src/contexts/AuthContext.tsx
@@ -77,7 +77,9 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     }
   };
 
-  const register = async (userData: Omit<User, 'id' | 'groups'> & { password: string }) => {
+  const register = async (
+    userData: Omit<User, 'id' | 'groups'> & { password: string }
+  ): Promise<boolean> => {
     setIsLoading(true);
     try {
       const { isSignUpComplete } = await signUp({
@@ -98,7 +100,11 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       if (isSignUpComplete) {
         // Auto-sign in after successful registration
         await login(userData.email, userData.password);
+      } else {
+        setIsLoading(false);
       }
+
+      return isSignUpComplete;
     } catch (error) {
       setIsLoading(false);
       throw error;

--- a/packages/frontend/src/pages/LoginPage.tsx
+++ b/packages/frontend/src/pages/LoginPage.tsx
@@ -36,9 +36,14 @@ const LoginPage = () => {
       await login(data.email, data.password);
       toast.success('Login successful', 'Welcome back!');
       navigate('/dashboard');
-    } catch (error) {
+    } catch (error: unknown) {
       console.error('Login error:', error);
-      toast.error('Login failed', 'Please check your credentials and try again.');
+      if ((error as { name?: string }).name === 'UserNotConfirmedException') {
+        toast.info('Please verify your email before logging in');
+        navigate('/verify', { state: { email: data.email } });
+      } else {
+        toast.error('Login failed', 'Please check your credentials and try again.');
+      }
     } finally {
       setIsLoading(false);
     }

--- a/packages/frontend/src/pages/RegisterPage.tsx
+++ b/packages/frontend/src/pages/RegisterPage.tsx
@@ -106,7 +106,7 @@ const RegisterPage = () => {
   const onSubmit = async (data: RegisterFormValues) => {
     setIsSubmitting(true);
     try {
-      await registerUser({
+      const completed = await registerUser({
         name: data.name,
         email: data.email,
         company: data.company,
@@ -114,9 +114,13 @@ const RegisterPage = () => {
         uplineSMD: data.uplineSMD,
         password: data.password,
       });
-      
       toast.success('Registration successful', 'Your account has been created!');
-      navigate('/dashboard');
+      if (completed) {
+        navigate('/dashboard');
+      } else {
+        toast.info('Check your email to verify your account');
+        navigate('/verify', { state: { email: data.email } });
+      }
     } catch (error) {
       console.error('Registration error:', error);
       toast.error('Registration failed', 'Please try again later.');

--- a/packages/frontend/src/pages/VerifyEmailPage.tsx
+++ b/packages/frontend/src/pages/VerifyEmailPage.tsx
@@ -1,0 +1,80 @@
+import React, { useState } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { Button } from '../components/ui/Button';
+import { Input } from '../components/ui/Input';
+import { toast } from '../components/ui/Toaster';
+import { confirmSignUp, resendSignUpCode } from 'aws-amplify/auth';
+
+const verifySchema = z.object({
+  email: z.string().email('Please enter a valid email'),
+  code: z.string().min(1, 'Verification code is required'),
+});
+
+type VerifyForm = z.infer<typeof verifySchema>;
+
+const VerifyEmailPage: React.FC = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const initialEmail = (location.state as { email?: string })?.email || '';
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const { register, handleSubmit, formState: { errors }, watch } = useForm<VerifyForm>({
+    resolver: zodResolver(verifySchema),
+    defaultValues: { email: initialEmail, code: '' },
+  });
+
+  const onSubmit = async (data: VerifyForm) => {
+    setIsSubmitting(true);
+    try {
+      await confirmSignUp({ username: data.email, confirmationCode: data.code });
+      toast.success('Verification successful', 'You can now sign in');
+      navigate('/login');
+    } catch (error) {
+      console.error('Verification error:', error);
+      toast.error('Verification failed', 'Invalid code or email');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const resend = async () => {
+    try {
+      const email = watch('email');
+      await resendSignUpCode({ username: email });
+      toast.success('Code resent', 'Check your email for a new code');
+    } catch (error) {
+      console.error('Resend code error:', error);
+      toast.error('Unable to resend code');
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex flex-col justify-center py-12 sm:px-6 lg:px-8">
+      <div className="sm:mx-auto sm:w-full sm:max-w-md">
+        <h1 className="text-center text-3xl font-bold text-gray-900">Verify Your Email</h1>
+        <p className="mt-2 text-center text-gray-600">Enter the code sent to your email address</p>
+      </div>
+      <div className="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
+        <div className="bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10">
+          <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+            <Input label="Email" {...register('email')} error={errors.email?.message} />
+            <Input label="Verification Code" {...register('code')} error={errors.code?.message} />
+            <div className="flex justify-between items-center">
+              <Button type="button" variant="outline" onClick={resend}>
+                Resend Code
+              </Button>
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting ? 'Verifying...' : 'Verify'}
+              </Button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default VerifyEmailPage;


### PR DESCRIPTION
## Summary
- add VerifyEmailPage for confirming user emails
- direct users to verify page when registration needs confirmation
- show verify hint on login when user not confirmed
- return sign-up completion flag from AuthContext.register
- expose verify route

## Testing
- `pnpm run frontend:lint`
- `pnpm run frontend:test`


------
https://chatgpt.com/codex/tasks/task_e_68430810e59c832d8888c668ba691421