### PR TITLE
Fix lint errors and update PNPM references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ point for the Amplify application. When planning new features or infrastructure,
 review these files first.
 
 ## Notes
-- This project uses Node 22+ and pnpm 10.11.1.
+ - This project uses Node 22+ and pnpm 10.12.1.
 - Backend design notes are tracked in the `app_design` directory.
 - Keep this guide current as the project evolves.
 

--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ Miliare/
 - AWS Lambda for custom business logic
 - Amplify CLI Gen 2 for infrastructure
 
-**Development:**
-- pnpm 10.11.0 for package management
+-**Development:**
+- pnpm 10.12.1 for package management
 - Node.js 22 runtime
 - TypeScript for type safety
 - ESLint and Prettier for code quality
@@ -106,7 +106,7 @@ Miliare/
 ### Prerequisites
 
 - Node.js 22+
-- pnpm 10.11.0+
+ - pnpm 10.12.1+
 - AWS CLI configured
 - Amplify CLI installed
 

--- a/app_design/Technical_Achievements.md
+++ b/app_design/Technical_Achievements.md
@@ -22,7 +22,7 @@ applications:
         preBuild:
           commands:
             - corepack enable
-            - corepack prepare pnpm@10.11.0 --activate
+            - corepack prepare pnpm@10.12.1 --activate
             - pnpm install --frozen-lockfile
         build:
           commands:
@@ -63,7 +63,7 @@ cache:
 preBuild:
   commands:
     - corepack enable
-    - corepack prepare pnpm@10.11.0 --activate
+    - corepack prepare pnpm@10.12.1 --activate
     - pnpm install --frozen-lockfile
 ```
 
@@ -270,7 +270,7 @@ phases:
     commands:
       - node --version  # Verify runtime
       - corepack enable
-      - corepack prepare pnpm@10.11.0 --activate
+      - corepack prepare pnpm@10.12.1 --activate
 ```
 
 ## 📈 Performance & Scalability Improvements

--- a/app_design/miliare-frontend/amplify.yml
+++ b/app_design/miliare-frontend/amplify.yml
@@ -13,7 +13,7 @@ backend:
       commands:
         - nvm use 22
         - corepack enable
-        - corepack prepare pnpm@10.11.0 --activate
+        - corepack prepare pnpm@10.12.1 --activate
         - pnpm install --frozen-lockfile --prefer-offline
         - npx ampx pipeline-deploy --branch $AWS_BRANCH --app-id $AWS_APP_ID
 frontend:
@@ -43,7 +43,7 @@ frontend:
       commands:
         - nvm use 22
         - corepack enable
-        - corepack prepare pnpm@10.11.0 --activate
+        - corepack prepare pnpm@10.12.1 --activate
         # Ensure NODE_OPTIONS is still set for build with XLarge memory
         - export NODE_OPTIONS="--max_old_space_size=50000 --max-semi-space-size=2048"
         # Production build with memory monitoring

--- a/app_design/miliare-frontend/package.json
+++ b/app_design/miliare-frontend/package.json
@@ -43,5 +43,5 @@
     "tw-animate-css": "^1.3.0",
     "typescript": "^5.6.2"
   },
-  "packageManager": "pnpm@10.11.1+sha512.e519b9f7639869dc8d5c3c5dfef73b3f091094b0a006d7317353c72b124e80e1afd429732e28705ad6bfa1ee879c1fce46c128ccebd3192101f43dd67c667912"
+  "packageManager": "pnpm@10.12.1"
 }

--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -23,7 +23,7 @@ the application.
 
 ## Useful commands
 
-This project requires **Node.js 22+**, **pnpm 10.11.1**, and **Go 1.24** when
+This project requires **Node.js 22+**, **pnpm 10.12.1**, and **Go 1.24** when
 building the Lambda functions. The basic workflow is:
 
 1. `pnpm install`

--- a/packages/frontend/src/components/EarningsChart.tsx
+++ b/packages/frontend/src/components/EarningsChart.tsx
@@ -79,7 +79,7 @@ const EarningsChart: React.FC<EarningsChartProps> = ({ data }) => {
             font: {
               size: 12,
             },
-            callback: function(value: any) {
+            callback: function(value: number) {
               return '$' + value.toLocaleString();
             },
           },
@@ -96,7 +96,7 @@ const EarningsChart: React.FC<EarningsChartProps> = ({ data }) => {
           borderColor: '#1e40af',
           borderWidth: 1,
           callbacks: {
-            label: function(context: any) {
+            label: function(context: { parsed: { y: number } }) {
               return 'Earnings: $' + context.parsed.y.toLocaleString();
             },
           },

--- a/packages/frontend/src/pages/dashboard/BusinessPage.tsx
+++ b/packages/frontend/src/pages/dashboard/BusinessPage.tsx
@@ -1,10 +1,4 @@
 import React, { useState } from 'react';
-import {
-  TrendingUp,
-  Clock,
-  DollarSign,
-  Users,
-} from 'lucide-react';
 import { Button } from '../../components/ui/Button';
 import { Link } from 'react-router-dom';
 import EarningsChart, { EarningsPoint } from '../../components/EarningsChart';


### PR DESCRIPTION
## Summary
- update PNPM version references to 10.12.1
- remove unused imports and fix types
- document updated version requirements

## Testing
- `pnpm run frontend:lint`
- `SKIP_BUNDLING=1 pnpm run backend:test` *(fails: ENOENT referral_schema.graphql)*

------
https://chatgpt.com/codex/tasks/task_b_68489112138483329de55ff1525d2e4e