### PR TITLE
Fix failing admin link test

### DIFF
--- a/packages/frontend/src/__tests__/AdminAccess.test.tsx
+++ b/packages/frontend/src/__tests__/AdminAccess.test.tsx
@@ -37,7 +37,7 @@ describe('Admin access', () => {
       </MemoryRouter>
     );
 
-    expect(screen.getByRole('link', { name: /admin/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /^Admin$/i })).toBeInTheDocument();
   });
 
   it('hides Admin link for users without admin group', () => {
@@ -58,7 +58,7 @@ describe('Admin access', () => {
       </MemoryRouter>
     );
 
-    expect(screen.queryByRole('link', { name: /admin/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /^Admin$/i })).not.toBeInTheDocument();
   });
 
   it('restricts /dashboard/admin route when user lacks admin group', () => {


### PR DESCRIPTION
## Summary
- fix selector for admin nav link in tests

## Testing
- `pnpm run frontend:lint`
- `pnpm run frontend:test`


------
https://chatgpt.com/codex/tasks/task_b_68489f9753b08332ae2d68c9efceaf8d